### PR TITLE
Allow HTTP, not just HTTPS connection

### DIFF
--- a/src/main/java/io/jenkins/plugins/infisicaljenkins/infisical/InfisicalAuth.java
+++ b/src/main/java/io/jenkins/plugins/infisicaljenkins/infisical/InfisicalAuth.java
@@ -16,11 +16,13 @@ public class InfisicalAuth implements Serializable {
 
     public String loginWithUniversalAuth(
             String infisicalUrl, String machineIdentityClientId, String machineIdentityClientSecret) {
-        HttpsURLConnection connection = null;
+        HttpURLConnection connection = null;
         try {
             // Create the URL, and append "/api/v1/auth/universal-auth/login" to it
             URL url = new URL(infisicalUrl + "/api/v1/auth/universal-auth/login");
-            connection = (HttpsURLConnection) url.openConnection();
+
+            if (infisicalUrl.contains("https")) connection = (HttpsURLConnection) url.openConnection();
+            else connection = (HttpURLConnection) url.openConnection();
 
             // Set request method to POST
             connection.setRequestMethod("POST");


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

I'm using a local jenkins deployment over HTTP, no SSL/TLS security. Getting this error when I use the infisical plugin:

```
java.lang.ClassCastException: class sun.net.www.protocol.http.HttpURLConnection cannot be cast to class javax.net.ssl.HttpsURLConnection (sun.net.www.protocol.http.HttpURLConnection and javax.net.ssl.HttpsURLConnection are in module java.base of loader 'bootstrap')
	at io.jenkins.plugins.infisicaljenkins.infisical.InfisicalAuth.loginWithUniversalAuth(InfisicalAuth.java:23)
	at io.jenkins.plugins.infisicaljenkins.credentials.InfisicalUniversalAuthCredential.getAccessToken(InfisicalUniversalAuthCredential.java:47)
	at io.jenkins.plugins.infisicaljenkins.infisical.InfisicalSecrets.getSecrets(InfisicalSecrets.java:34)
	at io.jenkins.plugins.infisicaljenkins.InfisicalAccessor.readSecretsFromInfisical(InfisicalAccessor.java:63)
	at io.jenkins.plugins.infisicaljenkins.InfisicalAccessor.fetchInfisicalSecrets(InfisicalAccessor.java:112)
	at io.jenkins.plugins.infisicaljenkins.InfisicalBuildWrapper.provideEnvironmentVariablesFromInfisical(InfisicalBuildWrapper.java:103)
	at io.jenkins.plugins.infisicaljenkins.InfisicalBuildWrapper.setUp(InfisicalBuildWrapper.java:71)
	at org.jenkinsci.plugins.workflow.steps.CoreWrapperStep$Execution2.doStart(CoreWrapperStep.java:121)
	at org.jenkinsci.plugins.workflow.steps.GeneralNonBlockingStepExecution.lambda$run$0(GeneralNonBlockingStepExecution.java:77)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
Finished: FAILURE
```
No idea how to test this tweak, was hoping I could just run the github actions in my fork, doesn't seem like I can. Happy to actually test it if that's how this works.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
