### PR TITLE
Adding JCasC and LDAP functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This plugin adds a build wrapper to set environment variables from [Infisical](h
 ## Infisical Authentication
 
 Authenticating with Infisical is done through the use of [Machine Identities](https://infisical.com/docs/documentation/platform/identities/machine-identities).
-Currently the Jenkins plugin only supports [Universal Auth](https://infisical.com/docs/documentation/platform/identities/universal-auth) for authentication. More methods will be added soon.
+Currently the Jenkins plugin supports [Universal Auth](https://infisical.com/docs/documentation/platform/identities/universal-auth)  and [LDAP Auth](https://infisical.com/docs/documentation/platform/identities/ldap-auth) for authentication. More methods will be added soon.
 
 ### How does Universal Auth work?
 To use Universal Auth, you'll need to create a new Credential _(Infisical Universal Auth Credential)_. The credential should contain your Universal Auth client ID, and your Universal Auth client secret.
@@ -24,7 +24,18 @@ The `ID` and `Description` field doesn't matter much in this case, as they won't
 
 ![Infisical Universal Auth Credential](docs/images/universal-auth-credential.png)
 
+### How does LDAP Auth work?
+To use LDAP Auth, you'll need to create a new Credential _(Infisical LDAP Auth Credential)_.  The credential should contain your IdentityId, LDAP username, and LDAP password.
+Please [read more here](https://infisical.com/docs/documentation/platform/identities/ldap-auth) on how to setup a Machine Identity to use LDAP authentication.
 
+
+### Creating an LDAP credential
+
+Simply navigate to `Dashboard -> Manage Jenkins -> Credentials -> System -> Global credentials (unrestricted)`.
+
+Press the `Add Credentials` button and select `Infisical LDAP Credential` in the `Kind` field.
+
+The `ID` and `Description` field doesn't matter much in this case, as they won't be read anywhere. The description field will be displayed as the credential name during the plugin configuration.
 
 ## Plugin Usage
 ### Configuration
@@ -106,3 +117,100 @@ node {
 }
 ```
 
+## Configuration as Code
+
+The Jenkins Configuration as Code plugin ([JCasC](https://github.com/casz/configuration-as-code-plugin)) allows you to configure Jenkins via a yaml file.
+
+Using this plugin, you can reference Infisical secrets in your JCasC yaml files.
+
+### Prerequisite: 
+Install 'Configuration as Code' Plugin on your Jenkins instance.
+
+Refer to [Installing a new plugin in Jenkins](https://jenkins.io/doc/book/managing/plugins/#installing-a-plugin).
+
+### Infisical Vault Plugin as a Secret Source for JCasC
+
+The JCasC plugin allows you to configure Infisical Jenkins credentials in the yaml configuration file and also allows you to reference secrets throughout the yaml file via string interpolation.
+
+### JCasC config for Jenkins Credentials
+
+JCasC can be used to create the Universal Auth and LDAP Authentication credentials which are used to look up secrets from Infisical.
+
+The secrets can be defined in the yaml file like so:
+
+```yaml
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+          - infisicalLdapCredential:
+              description: "Infisical LDAP Credential"
+              id: "infisical-ldap-credential"
+              identityId: "jenkins_identity_id"
+              password: "secret123!"
+              username: "infisical_username"
+              scope: SYSTEM
+          - infisicalUniversalAuthCredential:
+              description: "Infisical Universal Auth Credential"
+              id: "infisical-universal-auth-credential"
+              machineIdentityClientId: "machine_identity_client_id"
+              machineIdentityClientSecret: "machine_identity_client_secret"
+              scope: SYSTEM
+```
+
+### JCasC Infisical string interpolation in yaml file
+
+Note that the above example contains secret values stored in clear text.  This can be avoided by using string interpolation to replace the secret values from Infisical at load time.
+
+JCasC will need to access Infisical in order to perform the lookups for string interpolation.
+The connection information is provided via the following environment variables which must be present during Jenkins startup.
+
+General Variables:
+* CASC_INFISICAL_FILE: (Optional) Location of file which contains the environment variables (alternate way of providing variable values)
+* CASC_INFISICAL_URL: (Optional) URL for connecting to Infisical.  Defaults to https://app.infisical.com
+* CASC_INFISICAL_INCLUDE_IMPORTS: (Optional) Should imported secrets be processed? (defaults to FALSE)
+* CASC_INFISICAL_ENVIRONMENT_SLUG: Environment slug to pull secrets for.
+* CASC_INFISICAL_PROJECT_SLUG:  Project slug containing secrets.
+* CASC_INFISICAL_RECURSIVE:  (Optional) Should secrets from subfolders of CASC_INFISICAL_PATHS be retrieved? (defaults to FALSE)
+* CASC_INFISICAL_PATHS:  Comma delimited ist of paths to search for secrets in.  Only secrets in these folders will be retrieved for lookup.
+
+Universal Authentication Variables:
+* CASC_INFISICAL_MACHINE_IDENTITY_CLIENT_ID: Machine Identity Client Id used to authenticated with Infisical
+* CASC_INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET: Machine Identity Client Secret used
+
+LDAP Authentication Variables:
+* CASC_INFISICAL_LDAP_IDENTITY_ID: Identity ID for the machine id
+* CASC_INFISICAL_LDAP_USER: LDAP username associated with the machine id
+* CASC_INFISICAL_LDAP_PW: Password for the LDAP user
+
+Optional CASC_INFISICAL_FILE can be used to pass secrets via file instead of environment variables.  The file should be formatted like so:
+
+```properties
+CASC_INFISICAL_URL=https://app.infisical.com
+CASC_INFISICAL_ENVIRONMENT_SLUG=prod
+CASC_INFISICAL_PROJECT_SLUG=myproject
+CASC_INFISICAL_PATHS=/secrets/jenkins,/secrets/otherpath
+CASC_INFISICAL_LDAP_IDENTITY_ID=70ee8db9-8e15-4022-92c1-0d46232ebf82
+CASC_INFISICAL_LDAP_USER=username
+CASC_INFISICAL_LDAP_PW=secret123!
+```
+
+### Referencing Infisical secrets in JCasC yaml
+
+To use string interpolation to replace secrets in the JCasC yaml file reference them with ${} notation.
+
+In this example the secret values will be pulled from Infisical as long as the environment variables are configured:
+```yaml
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+          - usernamePassword:
+              description: "Database Credentials"
+              id: "database-credential"
+              password: "${DATABASE_PASSWORD}"
+              username: "${DATABASE_USERNAME}"
+              scope: GLOBAL 
+```
+
+In the above example the "password" value would be pulled from Infisical in secrets named DATABASE_PASSWORD and DATABASE_USERNAME.

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,10 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>gson-api</artifactId>
     </dependency>

--- a/src/main/java/io/jenkins/plugins/infisicaljenkins/InfisicalAccessor.java
+++ b/src/main/java/io/jenkins/plugins/infisicaljenkins/InfisicalAccessor.java
@@ -61,7 +61,12 @@ public class InfisicalAccessor implements Serializable {
 
         // Fetch all secrets in the project, environment, and path
         List<SingleSecretResponse> allSecretsInPath = InfisicalSecrets.getSecrets(
-                configuration, this.credential, infisicalSecret.getPath(), infisicalSecret.getIncludeImports(), logger);
+                configuration,
+                this.credential,
+                infisicalSecret.getPath(),
+                infisicalSecret.getIncludeImports(),
+                false,
+                logger);
 
         logger.printf("Found %d secrets in path: %s%n", allSecretsInPath.size(), infisicalSecret.getPath());
 

--- a/src/main/java/io/jenkins/plugins/infisicaljenkins/credentials/AbstractInfisicalLdapCredential.java
+++ b/src/main/java/io/jenkins/plugins/infisicaljenkins/credentials/AbstractInfisicalLdapCredential.java
@@ -1,0 +1,11 @@
+package io.jenkins.plugins.infisicaljenkins.credentials;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+
+public abstract class AbstractInfisicalLdapCredential extends BaseStandardCredentials implements InfisicalCredential {
+
+    protected AbstractInfisicalLdapCredential(CredentialsScope scope, String id, String description) {
+        super(scope, id, description);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/infisicaljenkins/credentials/InfisicalLdapCredential.java
+++ b/src/main/java/io/jenkins/plugins/infisicaljenkins/credentials/InfisicalLdapCredential.java
@@ -10,53 +10,67 @@ import io.jenkins.plugins.infisicaljenkins.infisical.InfisicalAuth;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-public class InfisicalUniversalAuthCredential extends AbstractAuthenticatingInfisicalTokenCredential {
+public class InfisicalLdapCredential extends AbstractAuthenticatingInfisicalTokenCredential {
 
     @NonNull
-    private String machineIdentityClientId;
+    private String identityId;
 
     @NonNull
-    private String machineIdentityClientSecret;
+    private String username;
+
+    @NonNull
+    private String password;
 
     private final InfisicalAuth infisicalAuth;
 
     @DataBoundConstructor
-    public InfisicalUniversalAuthCredential(
+    public InfisicalLdapCredential(
             @CheckForNull CredentialsScope scope,
             @CheckForNull String id,
             @CheckForNull String description,
-            @NonNull String machineIdentityClientId,
-            @NonNull String machineIdentityClientSecret) {
+            @NonNull String identityId,
+            @NonNull String username,
+            @NonNull String password) {
         super(scope, id, description);
         this.infisicalAuth = new InfisicalAuth();
-        this.machineIdentityClientId = machineIdentityClientId;
-        this.machineIdentityClientSecret = machineIdentityClientSecret;
+        this.identityId = identityId;
+        this.username = username;
+        this.password = password;
     }
 
     @NonNull
-    public String getMachineIdentityClientId() {
-        return machineIdentityClientId;
+    public String getIdentityId() {
+        return identityId;
     }
 
     @NonNull
-    public String getMachineIdentityClientSecret() {
-        return machineIdentityClientSecret;
+    public String getUsername() {
+        return username;
+    }
+
+    @NonNull
+    public String getPassword() {
+        return password;
     }
 
     @DataBoundSetter
-    public void setMachineIdentityClientId(String machineIdentityClientId) {
-        this.machineIdentityClientId = machineIdentityClientId;
+    public void setIdentityId(String identityId) {
+        this.identityId = identityId;
     }
 
     @DataBoundSetter
-    public void setMachineIdentityClientSecret(String machineIdentityClientSecret) {
-        this.machineIdentityClientSecret = machineIdentityClientSecret;
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    @DataBoundSetter
+    public void setPassword(String password) {
+        this.password = password;
     }
 
     public String getAccessToken(InfisicalConfiguration configuration) {
         try {
-            return infisicalAuth.loginWithUniversalAuth(
-                    configuration.getInfisicalUrl(), machineIdentityClientId, machineIdentityClientSecret);
+            return infisicalAuth.loginWithLdapAuth(configuration.getInfisicalUrl(), identityId, username, password);
 
         } catch (InfisicalPluginException e) {
             throw new InfisicalPluginException("Failed to authenticate with Infisical", e);
@@ -69,7 +83,7 @@ public class InfisicalUniversalAuthCredential extends AbstractAuthenticatingInfi
         @NonNull
         @Override
         public String getDisplayName() {
-            return "Infisical Universal Auth Credential";
+            return "Infisical LDAP Credential";
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/infisicaljenkins/infisical/InfisicalAuth.java
+++ b/src/main/java/io/jenkins/plugins/infisicaljenkins/infisical/InfisicalAuth.java
@@ -14,6 +14,45 @@ import org.json.JSONObject;
 
 public class InfisicalAuth implements Serializable {
 
+    public String loginWithLdapAuth(String infisicalUrl, String identityId, String username, String password) {
+        HttpsURLConnection connection = null;
+        try {
+            URL url = new URL(infisicalUrl + "/api/v1/auth/ldap-auth/login");
+            connection = (HttpsURLConnection) url.openConnection();
+
+            // Set request method to POST
+            connection.setRequestMethod("POST");
+            connection.setDoOutput(true);
+
+            // Set headers
+            connection.setRequestProperty("Content-Type", "application/json");
+            connection.setRequestProperty("Accept", "application/json");
+
+            // Create JSON body
+            JSONObject jsonBody = new JSONObject();
+            jsonBody.put("identityId", identityId);
+            jsonBody.put("username", username);
+            jsonBody.put("password", password);
+            String jsonInputString = jsonBody.toString();
+
+            // Send request
+            try (DataOutputStream wr = new DataOutputStream(connection.getOutputStream())) {
+                wr.write(jsonInputString.getBytes(StandardCharsets.UTF_8));
+            }
+
+            String accessToken = getTokenFromConnection(connection);
+            return String.format("Bearer %s", accessToken);
+
+        } catch (IOException ex) {
+            ex.printStackTrace();
+            throw new InfisicalPluginException(ex.getMessage());
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
     public String loginWithUniversalAuth(
             String infisicalUrl, String machineIdentityClientId, String machineIdentityClientSecret) {
         HttpsURLConnection connection = null;
@@ -41,29 +80,50 @@ public class InfisicalAuth implements Serializable {
                 wr.write(jsonInputString.getBytes(StandardCharsets.UTF_8));
             }
 
-            // Check response code
-            int responseCode = connection.getResponseCode();
-            if (responseCode == HttpURLConnection.HTTP_OK) { // success
-                BufferedReader in =
-                        new BufferedReader(new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
+            String accessToken = getTokenFromConnection(connection);
+            return String.format("Bearer %s", accessToken);
 
-                String inputLine;
-                StringBuffer response = new StringBuffer();
-
-                while ((inputLine = in.readLine()) != null) {
-                    response.append(inputLine);
-                }
-                in.close();
-
-                // Parse the response using org.json
-                JSONObject jsonResponse = new JSONObject(response.toString());
-                String accessToken = jsonResponse.getString("accessToken"); // Extract the access token
-
-                return String.format("Bearer %s", accessToken);
-            } else {
-                throw new InfisicalPluginException(
-                        "Failed to authenticate with Infisical. Response code: " + responseCode);
+        } catch (IOException ex) {
+            ex.printStackTrace();
+            throw new InfisicalPluginException(ex.getMessage());
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
             }
+        }
+    }
+
+    private String getTokenFromConnection(HttpURLConnection connection) throws InfisicalPluginException, IOException {
+        // Check response code
+        int responseCode = connection.getResponseCode();
+        if (responseCode == HttpURLConnection.HTTP_OK) { // success
+            BufferedReader in =
+                    new BufferedReader(new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
+
+            String inputLine;
+            StringBuffer response = new StringBuffer();
+
+            while ((inputLine = in.readLine()) != null) {
+                response.append(inputLine);
+            }
+            in.close();
+
+            // Parse the response using org.json
+            JSONObject jsonResponse = new JSONObject(response.toString());
+            return jsonResponse.getString("accessToken"); // Extract the access token
+        } else {
+            throw new InfisicalPluginException("Failed to authenticate with Infisical. Response code: " + responseCode);
+        }
+    }
+
+    public void revoke(String infisicalUrl, String token) {
+        HttpsURLConnection connection = null;
+        try {
+            URL url = new URL(infisicalUrl + "/api/v1/auth/token/revoke");
+            connection = (HttpsURLConnection) url.openConnection();
+            connection.setRequestProperty("Content-Type", "application/json");
+            connection.setRequestProperty("Accept", "application/json");
+
         } catch (IOException ex) {
             ex.printStackTrace();
             throw new InfisicalPluginException(ex.getMessage());

--- a/src/main/java/io/jenkins/plugins/infisicaljenkins/infisical/InfisicalSecretSource.java
+++ b/src/main/java/io/jenkins/plugins/infisicaljenkins/infisical/InfisicalSecretSource.java
@@ -1,0 +1,195 @@
+package io.jenkins.plugins.infisicaljenkins.infisical;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import hudson.Extension;
+import io.jenkins.plugins.casc.SecretSource;
+import io.jenkins.plugins.infisicaljenkins.configuration.InfisicalConfiguration;
+import io.jenkins.plugins.infisicaljenkins.credentials.InfisicalCredential;
+import io.jenkins.plugins.infisicaljenkins.credentials.InfisicalLdapCredential;
+import io.jenkins.plugins.infisicaljenkins.credentials.InfisicalUniversalAuthCredential;
+import io.jenkins.plugins.infisicaljenkins.model.SingleSecretResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.commons.lang.StringUtils;
+
+@Extension(optional = true)
+public class InfisicalSecretSource extends SecretSource {
+
+    private static final Logger LOGGER = Logger.getLogger(InfisicalSecretSource.class.getName());
+
+    // General Properties
+
+    private static final String CASC_INFISICAL_ENVIRONMENT_SLUG = "CASC_INFISICAL_ENVIRONMENT_SLUG";
+    private static final String CASC_INFISICAL_FILE = "CASC_INFISICAL_FILE";
+    private static final String CASC_INFISICAL_INCLUDE_IMPORTS = "CASC_INFISICAL_INCLUDE_IMPORTS";
+    private static final String CASC_INFISICAL_PROJECT_SLUG = "CASC_INFISICAL_PROJECT_SLUG";
+    private static final String CASC_INFISICAL_PATHS = "CASC_INFISICAL_PATHS";
+    private static final String CASC_INFISICAL_URL = "CASC_INFISICAL_URL";
+
+    // Universal Authentication
+    private static final String CASC_INFISICAL_MACHINE_IDENTITY_CLIENT_ID = "CASC_INFISICAL_MACHINE_IDENTITY_CLIENT_ID";
+    private static final String CASC_INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET =
+            "CASC_INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET";
+
+    // LDAP Authentication
+    private static final String CASC_INFISICAL_LDAP_IDENTITY_ID = "CASC_INFISICAL_LDAP_IDENTITY_ID";
+    private static final String CASC_INFISICAL_LDAP_USER = "CASC_INFISICAL_LDAP_USER";
+    private static final String CASC_INFISICAL_LDAP_PW = "CASC_INFISICAL_LDAP_PW";
+    private static final String CASC_INFISICAL_RECURSIVE = "CASC_INFISICAL_RECURSIVE";
+
+    private InfisicalCredential credential;
+    private List<SingleSecretResponse> secrets;
+    private InfisicalConfiguration configuration;
+    private Properties prop;
+
+    private static final String CREDENTIALS_ID = "LDAP_Credential_for_JCASC";
+
+    public void init() {
+        prop = new Properties();
+        Optional<String> propsFile = Optional.ofNullable(System.getenv(CASC_INFISICAL_FILE));
+        propsFile.ifPresent(this::readPropertiesFromFile);
+
+        // LDAP properties
+        Optional<String> ldapIdentityId = getVariable(CASC_INFISICAL_LDAP_IDENTITY_ID);
+        Optional<String> ldapUser = getVariable(CASC_INFISICAL_LDAP_USER);
+        Optional<String> ldapPw = getVariable(CASC_INFISICAL_LDAP_PW);
+
+        // Universal Auth properties
+        Optional<String> machineIdentityClientId = getVariable(CASC_INFISICAL_MACHINE_IDENTITY_CLIENT_ID);
+        Optional<String> machineIdentityClientSecret = getVariable(CASC_INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET);
+
+        // General properties
+        Optional<String> environmentSlug = getVariable(CASC_INFISICAL_ENVIRONMENT_SLUG);
+        Optional<String> infisicalUrl = getVariable(CASC_INFISICAL_URL);
+        Optional<String> includeImports = getVariable(CASC_INFISICAL_INCLUDE_IMPORTS);
+        Optional<String> projectSlug = getVariable(CASC_INFISICAL_PROJECT_SLUG);
+        Optional<String> recursive = getVariable(CASC_INFISICAL_RECURSIVE);
+        String[] paths = getVariable(CASC_INFISICAL_PATHS).orElse("/").split(",");
+
+        CredentialsScope scope = CredentialsScope.SYSTEM;
+
+        credential = null;
+
+        // Verify common properties are set
+        if (environmentSlug.isEmpty() || projectSlug.isEmpty()) {
+            LOGGER.info("Configuration missing.  Not using Infisical to perform JCasC variable lookup.");
+            return;
+        }
+
+        // Determine credentials type
+        if (ldapIdentityId.isPresent() && ldapUser.isPresent() && ldapPw.isPresent()) {
+            LOGGER.info("Using LDAP credentials");
+            credential = new InfisicalLdapCredential(
+                    scope,
+                    CREDENTIALS_ID,
+                    "LDAP Credential for JCASC",
+                    ldapIdentityId.get(),
+                    ldapUser.get(),
+                    ldapPw.get());
+        } else if (machineIdentityClientId.isPresent() && machineIdentityClientSecret.isPresent()) {
+            LOGGER.info("Using Universal Auth credentials");
+            credential = new InfisicalUniversalAuthCredential(
+                    scope,
+                    CREDENTIALS_ID,
+                    "LDAP Credential for JCASC",
+                    machineIdentityClientId.get(),
+                    machineIdentityClientSecret.get());
+        } else {
+            LOGGER.info("No credentials found.  Not using Infisical to perform JCasC variable lookup.");
+            return;
+        }
+
+        configuration = new InfisicalConfiguration();
+        configuration.setInfisicalCredentialId(CREDENTIALS_ID);
+        configuration.setInfisicalUrl(infisicalUrl.orElse(null));
+        configuration.setInfisicalProjectSlug(projectSlug.get());
+        configuration.setInfisicalEnvironmentSlug(environmentSlug.get());
+
+        retrieveSecrets(
+                paths,
+                Boolean.parseBoolean(includeImports.orElse("false")),
+                Boolean.parseBoolean(recursive.orElse("false")));
+    }
+
+    private void retrieveSecrets(String[] paths, boolean includeImports, boolean recursive) {
+        secrets = new ArrayList<>();
+
+        for (String p : paths) {
+            p = p.trim();
+
+            PrintStream ps = null;
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try {
+                ps = new PrintStream(baos, true, StandardCharsets.UTF_8);
+                List<SingleSecretResponse> fetched =
+                        InfisicalSecrets.getSecrets(configuration, credential, p, includeImports, recursive, ps);
+                if (!fetched.isEmpty()) {
+                    secrets.addAll(fetched);
+                }
+            } finally {
+                if (ps != null) {
+                    ps.flush();
+                    LOGGER.info(baos.toString(StandardCharsets.UTF_8));
+                    ps.close();
+                }
+            }
+        }
+    }
+
+    private Optional<String> getVariable(String key) {
+        return Optional.ofNullable(prop.getProperty(key, System.getenv(key)));
+    }
+
+    private void readPropertiesFromFile(String propsFile) {
+        try (FileInputStream input = new FileInputStream(propsFile)) {
+            prop.load(input);
+            if (prop.isEmpty()) {
+                LOGGER.log(Level.WARNING, "Infisical properties file is empty");
+            }
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Failed to load Infisical properties from file", e);
+        }
+    }
+
+    @Override
+    public Optional<String> reveal(String secret) {
+        if (StringUtils.isBlank(secret)) {
+            return Optional.empty();
+        }
+
+        if (configuration == null) {
+            return Optional.empty();
+        }
+        try {
+            configuration.fixDefaults();
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Failed to prepare Infisical configuration for JCasC", e);
+            return Optional.empty();
+        }
+        try {
+            if (secrets == null || secrets.isEmpty()) {
+                return Optional.empty();
+            }
+
+            for (SingleSecretResponse s : secrets) {
+                if (secret.equals(s.getSecretKey())) {
+                    return Optional.ofNullable(s.getSecretValue());
+                }
+            }
+
+            return Optional.empty();
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Failed to reveal Infisical secret for JCasC", e);
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/infisicaljenkins/infisical/InfisicalSecrets.java
+++ b/src/main/java/io/jenkins/plugins/infisicaljenkins/infisical/InfisicalSecrets.java
@@ -25,6 +25,7 @@ public class InfisicalSecrets implements Serializable {
             InfisicalCredential credential,
             String secretPath,
             boolean includeImports,
+            boolean recursive,
             PrintStream logger) {
 
         String accessToken;
@@ -39,13 +40,14 @@ public class InfisicalSecrets implements Serializable {
         try {
             // Updated to include the secretPath as a query parameter
             String urlString = String.format(
-                    "%s%s?secretPath=%s&workspaceSlug=%s&environment=%s&expandSecretReferences=true&include_imports=%s",
+                    "%s%s?secretPath=%s&workspaceSlug=%s&environment=%s&expandSecretReferences=true&include_imports=%s&recursive=%s",
                     configuration.getInfisicalUrl(),
                     "/api/v3/secrets/raw",
                     URLEncoder.encode(secretPath, "UTF-8"),
                     configuration.getInfisicalProjectSlug(),
                     configuration.getInfisicalEnvironmentSlug(),
-                    includeImports ? "true" : "false");
+                    includeImports ? "true" : "false",
+                    recursive ? "true" : "false");
 
             logger.println("Fetching secrets from Infisical at: " + urlString);
 

--- a/src/main/resources/io/jenkins/plugins/infisicaljenkins/configuration/InfisicalConfiguration/help-infisicalCredentialId.html
+++ b/src/main/resources/io/jenkins/plugins/infisicaljenkins/configuration/InfisicalConfiguration/help-infisicalCredentialId.html
@@ -1,5 +1,6 @@
 <div>
-	The Infisical credential is the credential you want to use to authenticate with Infisical. Currently only Universal Authentication is supported.
+	The Infisical credential is the credential you want to use to authenticate with Infisical. Currently only Universal Authentication and LDAP Authentication are supported.
 	<br />
-	<a href="https://infisical.com/docs/documentation/platform/identities/universal-auth">Read more about authentication</a>.
+	<a href="https://infisical.com/docs/documentation/platform/identities/universal-auth">Read more about Universal Authentication</a>.
+    <a href="https://infisical.com/docs/documentation/platform/identities/ldap-auth">Read more about LDAP Authentication</a>.
 </div>

--- a/src/main/resources/io/jenkins/plugins/infisicaljenkins/credentials/InfisicalLdapCredential/credentials.jelly
+++ b/src/main/resources/io/jenkins/plugins/infisicaljenkins/credentials/InfisicalLdapCredential/credentials.jelly
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+  <f:entry title="Identity ID">
+    <f:textbox field="identityId" name="identityId"/>
+  </f:entry>
+  <f:entry title="LDAP Username">
+    <f:textbox field="username" name="username"/>
+  </f:entry>
+  <f:entry title="LDAP Password">
+    <f:password field="password" name="password"/>
+  </f:entry>
+  <st:include page="id-and-description" class="${descriptor.clazz}"/>
+</j:jelly>


### PR DESCRIPTION
Adding LDAP Authentication as a credential type.

Also adding JCasC integration.

### Testing done

JCasC Testing:

Tested that Jenkins starts fine when environment variables are missing.

Tested by adding JCasC configuration to yaml file, setting environment variables, and verifying that text substitution occurs.

Tested by Adding JCasC configuration to yaml, creating properties file, and verifying that text substitution occurs.

Verified that Jenkins does not crash when secret value is missing from Infisical.

LDAP Credential Testing:

Created an LDAP credential and used it to pull secrets from Infisical in a Jenkins job


### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
